### PR TITLE
Update uv_build version automatically

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -5,10 +5,36 @@ name: Cron
 on:
   schedule:
   - cron: "0 6 * * *"  # daily at 6am
+  workflow_dispatch:
 
 jobs:
   test:
     if: github.repository_owner == 'pypa'  # suppress noise in forks
     uses: ./.github/workflows/test.yml
+
+  update-uv-build-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - name: Update uv_build version
+        id: update_script
+        run: uv run scripts/update_uv_build_version.py
+      - # If there are no changes, no pull request will be created and the action exits silently.
+        name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: Update uv_build version to ${{ steps.update_script.outputs.version }}
+          title: Update uv_build version to ${{ steps.update_script.outputs.version }}
+          body: |
+            Automated update of uv_build version bounds for uv ${{ steps.update_script.outputs.version }}.
+            
+            This PR was created automatically by the cron workflow, ping `@konstin` for problems.
+          branch: bot/update-uv-build-version
+          delete-branch: true
 
 ...

--- a/scripts/update_uv_build_version.py
+++ b/scripts/update_uv_build_version.py
@@ -1,0 +1,56 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "httpx>=0.28.1,<0.29",
+#     "packaging>=25.0",
+# ]
+# ///
+import re
+from pathlib import Path
+
+import httpx
+from packaging.utils import parse_wheel_filename
+from packaging.version import Version
+
+
+def main():
+    response = httpx.get(
+        "https://pypi.org/simple/uv-build/",
+        headers={"Accept": "application/vnd.pypi.simple.v1+json"},
+    )
+    response.raise_for_status()
+    data = response.json()
+    current_release = None
+    for file in data["files"]:
+        if not file["filename"].endswith(".whl"):
+            continue
+        _name, version, _build, _tags = parse_wheel_filename(file["filename"])
+        if version.is_prerelease:
+            continue
+        if current_release is None or version > current_release:
+            current_release = version
+
+    [major, minor, _patch] = current_release.release
+    if major != 0:
+        raise NotImplementedError("The script needs to be updated for uv 1.x")
+    upper_bound = Version(f"{major}.{minor + 1}.{0}")
+
+    repository_root = Path(__file__).parent.parent
+    existing = repository_root.joinpath("source/shared/build-backend-tabs.rst").read_text()
+    replacement = f'requires = ["uv_build >= {current_release}, <{upper_bound}"]'
+    searcher = re.compile(re.escape('requires = ["uv_build') + ".*" + re.escape('"]'))
+    if not searcher.search(existing):
+        raise RuntimeError("Could not `uv-build` entry")
+    updated = searcher.sub(replacement, existing)
+
+    if existing != updated:
+        print("Updating source/shared/build-backend-tabs.rst")
+        Path("source/shared/build-backend-tabs.rst").write_text(updated)
+        print(f"::set-output name=version::{current_release}")
+        print(f"::set-output name=updated::true")
+    else:
+        print("Already up-to-date source/shared/build-backend-tabs.rst")
+        print(f"::set-output name=updated::false")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
In https://github.com/pypa/packaging.python.org/pull/1880, the concern was raised that the uv_build upper bound in the docs will go stale. This PR adds a GitHub Actions workflow that automatically updates the version daily with the latest uv(-build) version.

I tested this change on my fork, but I unfortunately can't test this in pypa/packaging.python.org itself.

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1.org.readthedocs.build/en/1/

<!-- readthedocs-preview python-packaging-user-guide end -->